### PR TITLE
Fix webrtcvad error handling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 
 import numpy as np
 import webrtcvad
+import _webrtcvad
 import discord
 from discord.ext import commands
 import whisper
@@ -48,7 +49,7 @@ class VADSink(discord.sinks.Sink):
         mono = np.frombuffer(data, dtype=np.int16)[::2].tobytes()
         try:
             speech = self.vad.is_speech(mono, sample_rate=48000)
-        except webrtcvad.Error:
+        except _webrtcvad.Error:
             # ignore frames of an invalid size
             return
         now = time.monotonic()


### PR DESCRIPTION
## Summary
- catch `_webrtcvad.Error` raised by `is_speech`

## Testing
- `python -m py_compile bot.py`
- `python bot.py -h` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6841997ff8a08331bbb86e9634aac7a9