### PR TITLE
Fix compute type warning on CPU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+run.log

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ This repository contains an example Discord bot that records users in a voice ch
 
 ## Setup
 
-Install dependencies with `pip` (Python 3.11 recommended):
+Install dependencies with `pip` (Python 3.10 or higher recommended):
 
 ```bash
-pip install py-cord openai-whisper torch webrtcvad numpy tqdm tiktoken more-itertools numba PyNaCl
+pip install py-cord openai-whisper torch webrtcvad numpy tqdm tiktoken more-itertools numba PyNaCl RealtimeSTT
 ```
 
 FFmpeg must also be installed and accessible in `PATH`.
+The bot relies on the [RealtimeSTT](https://pypi.org/project/RealtimeSTT/) package
+for on-the-fly transcription, so ensure it is installed as shown above.
 
 Create a Discord application and bot token, then set the environment variable:
 
@@ -30,5 +32,11 @@ Run the bot:
 ```bash
 python bot.py
 ```
+
+On Windows, the script must be executed directly (not imported) to avoid
+multiprocessing startup errors.
+
+The recorder is initialized to use the CPU with float32 precision to avoid
+`ctranslate2` compute type warnings.
 
 Use `!join` in a text channel while connected to a voice channel to start recording, and `!leave` to stop.

--- a/bot.py
+++ b/bot.py
@@ -17,8 +17,8 @@ TOKEN = os.getenv("DISCORD_TOKEN")
 if not TOKEN:
     raise RuntimeError("DISCORD_TOKEN environment variable is not set")
 
-# initialize RealtimeSTT recorder without microphone
-recorder = AudioToTextRecorder(use_microphone=False)
+# placeholder for RealtimeSTT recorder instance
+recorder = None
 
 intents = discord.Intents.default()
 intents.message_content = True
@@ -130,4 +130,18 @@ async def leave(ctx: commands.Context):
     else:
         await ctx.send("Not in a voice channel")
 
-bot.run(TOKEN)
+
+def main():
+    global recorder
+    # initialize RealtimeSTT recorder without microphone
+    # explicitly use CPU with float32 to avoid ctranslate2 warnings
+    recorder = AudioToTextRecorder(
+        use_microphone=False,
+        device="cpu",
+        compute_type="float32",
+    )
+    bot.run(TOKEN)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- set AudioToTextRecorder device to CPU with float32 compute type
- mention CPU compute type in README

## Testing
- `python -m py_compile bot.py speech_segmenter.py`
- `python bot.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6841afd79ba88331984ed0191d7e2492